### PR TITLE
Fix typo in initialization message

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ const main = async () => {
     try {
         await initLocale();
     } catch (error) {
-        console.log(`[main.ts] Language initalization failed:`, error);
+        console.log(`[main.ts] Language initialization failed:`, error);
     }
 
     app.use(createPinia());


### PR DESCRIPTION
## Summary
- fix spelling of "initialization" in log output

## Testing
- `pnpm run type-check` *(fails: fetch error)*

------
https://chatgpt.com/codex/tasks/task_e_684569f9040483229312046dc5724229